### PR TITLE
Add PayPal Payment Intent and User Action Support

### DIFF
--- a/android/.idea/caches/deviceStreaming.xml
+++ b/android/.idea/caches/deviceStreaming.xml
@@ -4,6 +4,18 @@
     <option name="deviceSelectionList">
       <list>
         <PersistentDeviceSelectionData>
+          <option name="api" value="34" />
+          <option name="brand" value="Sony" />
+          <option name="codename" value="A402SO" />
+          <option name="id" value="A402SO" />
+          <option name="labId" value="google" />
+          <option name="manufacturer" value="Sony" />
+          <option name="name" value="Xperia 10" />
+          <option name="screenDensity" value="450" />
+          <option name="screenX" value="1080" />
+          <option name="screenY" value="2520" />
+        </PersistentDeviceSelectionData>
+        <PersistentDeviceSelectionData>
           <option name="api" value="27" />
           <option name="brand" value="DOCOMO" />
           <option name="codename" value="F01L" />
@@ -14,6 +26,18 @@
           <option name="screenDensity" value="360" />
           <option name="screenX" value="720" />
           <option name="screenY" value="1280" />
+        </PersistentDeviceSelectionData>
+        <PersistentDeviceSelectionData>
+          <option name="api" value="34" />
+          <option name="brand" value="OnePlus" />
+          <option name="codename" value="OP535DL1" />
+          <option name="id" value="OP535DL1" />
+          <option name="labId" value="google" />
+          <option name="manufacturer" value="OnePlus" />
+          <option name="name" value="CPH2409" />
+          <option name="screenDensity" value="401" />
+          <option name="screenX" value="1080" />
+          <option name="screenY" value="2412" />
         </PersistentDeviceSelectionData>
         <PersistentDeviceSelectionData>
           <option name="api" value="34" />
@@ -53,16 +77,15 @@
         </PersistentDeviceSelectionData>
         <PersistentDeviceSelectionData>
           <option name="api" value="34" />
-          <option name="brand" value="Lenovo" />
-          <option name="codename" value="TB370FU" />
-          <option name="formFactor" value="Tablet" />
-          <option name="id" value="TB370FU" />
+          <option name="brand" value="samsung" />
+          <option name="codename" value="a14m" />
+          <option name="id" value="a14m" />
           <option name="labId" value="google" />
-          <option name="manufacturer" value="Lenovo" />
-          <option name="name" value="Tab P12" />
-          <option name="screenDensity" value="340" />
-          <option name="screenX" value="1840" />
-          <option name="screenY" value="2944" />
+          <option name="manufacturer" value="Samsung" />
+          <option name="name" value="SM-A145R" />
+          <option name="screenDensity" value="450" />
+          <option name="screenX" value="1080" />
+          <option name="screenY" value="2408" />
         </PersistentDeviceSelectionData>
         <PersistentDeviceSelectionData>
           <option name="api" value="34" />
@@ -79,6 +102,30 @@
         <PersistentDeviceSelectionData>
           <option name="api" value="34" />
           <option name="brand" value="samsung" />
+          <option name="codename" value="a15x" />
+          <option name="id" value="a15x" />
+          <option name="labId" value="google" />
+          <option name="manufacturer" value="Samsung" />
+          <option name="name" value="A15 5G" />
+          <option name="screenDensity" value="450" />
+          <option name="screenX" value="1080" />
+          <option name="screenY" value="2340" />
+        </PersistentDeviceSelectionData>
+        <PersistentDeviceSelectionData>
+          <option name="api" value="34" />
+          <option name="brand" value="samsung" />
+          <option name="codename" value="a16x" />
+          <option name="id" value="a16x" />
+          <option name="labId" value="google" />
+          <option name="manufacturer" value="Samsung" />
+          <option name="name" value="A16 5G" />
+          <option name="screenDensity" value="450" />
+          <option name="screenX" value="1080" />
+          <option name="screenY" value="2340" />
+        </PersistentDeviceSelectionData>
+        <PersistentDeviceSelectionData>
+          <option name="api" value="34" />
+          <option name="brand" value="samsung" />
           <option name="codename" value="a35x" />
           <option name="id" value="a35x" />
           <option name="labId" value="google" />
@@ -87,18 +134,6 @@
           <option name="screenDensity" value="450" />
           <option name="screenX" value="1080" />
           <option name="screenY" value="2340" />
-        </PersistentDeviceSelectionData>
-        <PersistentDeviceSelectionData>
-          <option name="api" value="31" />
-          <option name="brand" value="samsung" />
-          <option name="codename" value="a51" />
-          <option name="id" value="a51" />
-          <option name="labId" value="google" />
-          <option name="manufacturer" value="Samsung" />
-          <option name="name" value="Galaxy A51" />
-          <option name="screenDensity" value="420" />
-          <option name="screenX" value="1080" />
-          <option name="screenY" value="2400" />
         </PersistentDeviceSelectionData>
         <PersistentDeviceSelectionData>
           <option name="api" value="34" />
@@ -149,6 +184,18 @@
           <option name="screenY" value="3088" />
         </PersistentDeviceSelectionData>
         <PersistentDeviceSelectionData>
+          <option name="api" value="34" />
+          <option name="brand" value="samsung" />
+          <option name="codename" value="b6q" />
+          <option name="id" value="b6q" />
+          <option name="labId" value="google" />
+          <option name="manufacturer" value="Samsung" />
+          <option name="name" value="Flip 6" />
+          <option name="screenDensity" value="340" />
+          <option name="screenX" value="1080" />
+          <option name="screenY" value="2640" />
+        </PersistentDeviceSelectionData>
+        <PersistentDeviceSelectionData>
           <option name="api" value="32" />
           <option name="brand" value="google" />
           <option name="codename" value="bluejay" />
@@ -173,7 +220,32 @@
           <option name="screenY" value="2142" />
         </PersistentDeviceSelectionData>
         <PersistentDeviceSelectionData>
+          <option name="api" value="35" />
+          <option name="brand" value="google" />
+          <option name="codename" value="caiman" />
+          <option name="id" value="caiman" />
+          <option name="labId" value="google" />
+          <option name="manufacturer" value="Google" />
+          <option name="name" value="Pixel 9 Pro" />
+          <option name="screenDensity" value="360" />
+          <option name="screenX" value="960" />
+          <option name="screenY" value="2142" />
+        </PersistentDeviceSelectionData>
+        <PersistentDeviceSelectionData>
           <option name="api" value="34" />
+          <option name="brand" value="google" />
+          <option name="codename" value="comet" />
+          <option name="default" value="true" />
+          <option name="id" value="comet" />
+          <option name="labId" value="google" />
+          <option name="manufacturer" value="Google" />
+          <option name="name" value="Pixel 9 Pro Fold" />
+          <option name="screenDensity" value="390" />
+          <option name="screenX" value="2076" />
+          <option name="screenY" value="2152" />
+        </PersistentDeviceSelectionData>
+        <PersistentDeviceSelectionData>
+          <option name="api" value="35" />
           <option name="brand" value="google" />
           <option name="codename" value="comet" />
           <option name="default" value="true" />
@@ -223,6 +295,18 @@
         </PersistentDeviceSelectionData>
         <PersistentDeviceSelectionData>
           <option name="api" value="34" />
+          <option name="brand" value="motorola" />
+          <option name="codename" value="dubai" />
+          <option name="id" value="dubai" />
+          <option name="labId" value="google" />
+          <option name="manufacturer" value="Motorola" />
+          <option name="name" value="edge 30" />
+          <option name="screenDensity" value="405" />
+          <option name="screenX" value="1080" />
+          <option name="screenY" value="2400" />
+        </PersistentDeviceSelectionData>
+        <PersistentDeviceSelectionData>
+          <option name="api" value="34" />
           <option name="brand" value="samsung" />
           <option name="codename" value="e1q" />
           <option name="default" value="true" />
@@ -257,6 +341,18 @@
           <option name="screenDensity" value="320" />
           <option name="screenX" value="384" />
           <option name="screenY" value="384" />
+        </PersistentDeviceSelectionData>
+        <PersistentDeviceSelectionData>
+          <option name="api" value="35" />
+          <option name="brand" value="motorola" />
+          <option name="codename" value="eqe" />
+          <option name="id" value="eqe" />
+          <option name="labId" value="google" />
+          <option name="manufacturer" value="Motorola" />
+          <option name="name" value="edge 50 pro" />
+          <option name="screenDensity" value="450" />
+          <option name="screenX" value="1220" />
+          <option name="screenY" value="2712" />
         </PersistentDeviceSelectionData>
         <PersistentDeviceSelectionData>
           <option name="api" value="33" />
@@ -308,6 +404,18 @@
         </PersistentDeviceSelectionData>
         <PersistentDeviceSelectionData>
           <option name="api" value="34" />
+          <option name="brand" value="motorola" />
+          <option name="codename" value="fogos" />
+          <option name="id" value="fogos" />
+          <option name="labId" value="google" />
+          <option name="manufacturer" value="Motorola" />
+          <option name="name" value="moto g34 5G" />
+          <option name="screenDensity" value="280" />
+          <option name="screenX" value="720" />
+          <option name="screenY" value="1600" />
+        </PersistentDeviceSelectionData>
+        <PersistentDeviceSelectionData>
+          <option name="api" value="34" />
           <option name="brand" value="samsung" />
           <option name="codename" value="g0q" />
           <option name="id" value="g0q" />
@@ -329,6 +437,18 @@
           <option name="screenDensity" value="240" />
           <option name="screenX" value="1200" />
           <option name="screenY" value="1920" />
+        </PersistentDeviceSelectionData>
+        <PersistentDeviceSelectionData>
+          <option name="api" value="33" />
+          <option name="brand" value="samsung" />
+          <option name="codename" value="gts7lwifi" />
+          <option name="id" value="gts7lwifi" />
+          <option name="labId" value="google" />
+          <option name="manufacturer" value="Samsung" />
+          <option name="name" value="SM-T870" />
+          <option name="screenDensity" value="340" />
+          <option name="screenX" value="1600" />
+          <option name="screenY" value="2560" />
         </PersistentDeviceSelectionData>
         <PersistentDeviceSelectionData>
           <option name="api" value="34" />
@@ -382,6 +502,18 @@
         </PersistentDeviceSelectionData>
         <PersistentDeviceSelectionData>
           <option name="api" value="34" />
+          <option name="brand" value="samsung" />
+          <option name="codename" value="gts9wifi" />
+          <option name="id" value="gts9wifi" />
+          <option name="labId" value="google" />
+          <option name="manufacturer" value="Samsung" />
+          <option name="name" value="SM-X710" />
+          <option name="screenDensity" value="340" />
+          <option name="screenX" value="1600" />
+          <option name="screenY" value="2560" />
+        </PersistentDeviceSelectionData>
+        <PersistentDeviceSelectionData>
+          <option name="api" value="34" />
           <option name="brand" value="google" />
           <option name="codename" value="husky" />
           <option name="id" value="husky" />
@@ -417,6 +549,18 @@
           <option name="screenY" value="2244" />
         </PersistentDeviceSelectionData>
         <PersistentDeviceSelectionData>
+          <option name="api" value="35" />
+          <option name="brand" value="google" />
+          <option name="codename" value="komodo" />
+          <option name="id" value="komodo" />
+          <option name="labId" value="google" />
+          <option name="manufacturer" value="Google" />
+          <option name="name" value="Pixel 9 Pro XL" />
+          <option name="screenDensity" value="360" />
+          <option name="screenX" value="1008" />
+          <option name="screenY" value="2244" />
+        </PersistentDeviceSelectionData>
+        <PersistentDeviceSelectionData>
           <option name="api" value="33" />
           <option name="brand" value="google" />
           <option name="codename" value="lynx" />
@@ -425,6 +569,30 @@
           <option name="manufacturer" value="Google" />
           <option name="name" value="Pixel 7a" />
           <option name="screenDensity" value="420" />
+          <option name="screenX" value="1080" />
+          <option name="screenY" value="2400" />
+        </PersistentDeviceSelectionData>
+        <PersistentDeviceSelectionData>
+          <option name="api" value="34" />
+          <option name="brand" value="motorola" />
+          <option name="codename" value="lyriq" />
+          <option name="id" value="lyriq" />
+          <option name="labId" value="google" />
+          <option name="manufacturer" value="Motorola" />
+          <option name="name" value="edge 40" />
+          <option name="screenDensity" value="400" />
+          <option name="screenX" value="1080" />
+          <option name="screenY" value="2400" />
+        </PersistentDeviceSelectionData>
+        <PersistentDeviceSelectionData>
+          <option name="api" value="34" />
+          <option name="brand" value="motorola" />
+          <option name="codename" value="manaus" />
+          <option name="id" value="manaus" />
+          <option name="labId" value="google" />
+          <option name="manufacturer" value="Motorola" />
+          <option name="name" value="edge 40 neo" />
+          <option name="screenDensity" value="400" />
           <option name="screenX" value="1080" />
           <option name="screenY" value="2400" />
         </PersistentDeviceSelectionData>
@@ -463,6 +631,18 @@
           <option name="screenDensity" value="420" />
           <option name="screenX" value="1080" />
           <option name="screenY" value="2400" />
+        </PersistentDeviceSelectionData>
+        <PersistentDeviceSelectionData>
+          <option name="api" value="35" />
+          <option name="brand" value="samsung" />
+          <option name="codename" value="pa3q" />
+          <option name="id" value="pa3q" />
+          <option name="labId" value="google" />
+          <option name="manufacturer" value="Samsung" />
+          <option name="name" value="Galaxy S25 Ultra" />
+          <option name="screenDensity" value="600" />
+          <option name="screenX" value="1440" />
+          <option name="screenY" value="3120" />
         </PersistentDeviceSelectionData>
         <PersistentDeviceSelectionData>
           <option name="api" value="33" />
@@ -576,6 +756,18 @@
           <option name="screenY" value="2560" />
         </PersistentDeviceSelectionData>
         <PersistentDeviceSelectionData>
+          <option name="api" value="35" />
+          <option name="brand" value="google" />
+          <option name="codename" value="tegu" />
+          <option name="id" value="tegu" />
+          <option name="labId" value="google" />
+          <option name="manufacturer" value="Google" />
+          <option name="name" value="Pixel 9a" />
+          <option name="screenDensity" value="420" />
+          <option name="screenX" value="1080" />
+          <option name="screenY" value="2424" />
+        </PersistentDeviceSelectionData>
+        <PersistentDeviceSelectionData>
           <option name="api" value="34" />
           <option name="brand" value="google" />
           <option name="codename" value="tokay" />
@@ -600,6 +792,18 @@
           <option name="screenDensity" value="420" />
           <option name="screenX" value="1080" />
           <option name="screenY" value="2424" />
+        </PersistentDeviceSelectionData>
+        <PersistentDeviceSelectionData>
+          <option name="api" value="34" />
+          <option name="brand" value="samsung" />
+          <option name="codename" value="xcover7" />
+          <option name="id" value="xcover7" />
+          <option name="labId" value="google" />
+          <option name="manufacturer" value="Samsung" />
+          <option name="name" value="SM-G556B" />
+          <option name="screenDensity" value="450" />
+          <option name="screenX" value="1080" />
+          <option name="screenY" value="2408" />
         </PersistentDeviceSelectionData>
       </list>
     </option>

--- a/android/src/main/kotlin/com/braintree/payment/Constants.kt
+++ b/android/src/main/kotlin/com/braintree/payment/Constants.kt
@@ -16,6 +16,7 @@ object Constants {
     const val ANDROID_DEEP_LINK_FALLBACK_URL_SCHEME = "androidDeepLinkFallbackUrlScheme"
     const val IOS_UNIVERSAL_LINK_RETURN_URL = "iosUniversalLinkReturnUrl"
     const val BILLING_AGREEMENT_DESCRIPTION = "billingAgreementDescription"
+    const val PAYMENT_INTENT = "paymentIntent"
 
     //Response keys
     const val NONCE_KEY = "nonce"

--- a/android/src/main/kotlin/com/braintree/payment/Constants.kt
+++ b/android/src/main/kotlin/com/braintree/payment/Constants.kt
@@ -17,6 +17,7 @@ object Constants {
     const val IOS_UNIVERSAL_LINK_RETURN_URL = "iosUniversalLinkReturnUrl"
     const val BILLING_AGREEMENT_DESCRIPTION = "billingAgreementDescription"
     const val PAYMENT_INTENT = "paymentIntent"
+    const val USER_ACTION = "userAction"
 
     //Response keys
     const val NONCE_KEY = "nonce"

--- a/android/src/main/kotlin/com/braintree/payment/PayPalActivity.kt
+++ b/android/src/main/kotlin/com/braintree/payment/PayPalActivity.kt
@@ -12,6 +12,8 @@ import com.braintreepayments.api.paypal.PayPalClient
 import com.braintreepayments.api.paypal.PayPalLauncher
 import com.braintreepayments.api.paypal.PayPalPaymentAuthRequest
 import com.braintreepayments.api.paypal.PayPalPaymentAuthResult
+import com.braintreepayments.api.paypal.PayPalPaymentIntent
+import com.braintreepayments.api.paypal.PayPalPaymentUserAction
 import com.braintreepayments.api.paypal.PayPalPendingRequest
 import com.braintreepayments.api.paypal.PayPalResult
 import org.json.JSONObject
@@ -39,6 +41,8 @@ class PayPalActivity : ComponentActivity() {
             intent.getStringExtra(Constants.ANDROID_DEEP_LINK_FALLBACK_URL_SCHEME)
         val billingAgreementDescription: String? =
             intent.getStringExtra(Constants.BILLING_AGREEMENT_DESCRIPTION)
+        val paymentIntent: String? =
+            intent.getStringExtra(Constants.PAYMENT_INTENT)
 
         paypalLauncher = PayPalLauncher()
         paypalClient = PayPalClient(
@@ -54,6 +58,11 @@ class PayPalActivity : ComponentActivity() {
             currencyCode = currencyCode,
             hasUserLocationConsent = true,
             billingAgreementDescription = billingAgreementDescription,
+            intent = when (paymentIntent) {
+                "sale" -> PayPalPaymentIntent.SALE
+                "order" -> PayPalPaymentIntent.ORDER
+                else -> PayPalPaymentIntent.AUTHORIZE
+            }
         )
 
         startPayPalFlow(payPalRequest)

--- a/android/src/main/kotlin/com/braintree/payment/PayPalActivity.kt
+++ b/android/src/main/kotlin/com/braintree/payment/PayPalActivity.kt
@@ -43,6 +43,8 @@ class PayPalActivity : ComponentActivity() {
             intent.getStringExtra(Constants.BILLING_AGREEMENT_DESCRIPTION)
         val paymentIntent: String? =
             intent.getStringExtra(Constants.PAYMENT_INTENT)
+        val userAction: String? =
+            intent.getStringExtra(Constants.USER_ACTION)
 
         paypalLauncher = PayPalLauncher()
         paypalClient = PayPalClient(
@@ -62,6 +64,10 @@ class PayPalActivity : ComponentActivity() {
                 "sale" -> PayPalPaymentIntent.SALE
                 "order" -> PayPalPaymentIntent.ORDER
                 else -> PayPalPaymentIntent.AUTHORIZE
+            },
+            userAction = when (userAction) {
+                "commit" -> PayPalPaymentUserAction.USER_ACTION_COMMIT
+                else -> PayPalPaymentUserAction.USER_ACTION_DEFAULT
             }
         )
 

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -13,19 +13,19 @@ PODS:
     - Braintree/DataCollector
   - Braintree/Venmo (6.30.0):
     - Braintree/Core
-  - braintree_payment (0.0.1):
+  - Flutter (1.0.0)
+  - flutter_braintree_payment (0.0.1):
     - Braintree (= 6.30.0)
     - Braintree/Venmo (= 6.30.0)
     - Flutter
-  - Flutter (1.0.0)
   - integration_test (0.0.1):
     - Flutter
   - package_info_plus (0.4.5):
     - Flutter
 
 DEPENDENCIES:
-  - braintree_payment (from `.symlinks/plugins/braintree_payment/ios`)
   - Flutter (from `Flutter`)
+  - flutter_braintree_payment (from `.symlinks/plugins/flutter_braintree_payment/ios`)
   - integration_test (from `.symlinks/plugins/integration_test/ios`)
   - package_info_plus (from `.symlinks/plugins/package_info_plus/ios`)
 
@@ -34,10 +34,10 @@ SPEC REPOS:
     - Braintree
 
 EXTERNAL SOURCES:
-  braintree_payment:
-    :path: ".symlinks/plugins/braintree_payment/ios"
   Flutter:
     :path: Flutter
+  flutter_braintree_payment:
+    :path: ".symlinks/plugins/flutter_braintree_payment/ios"
   integration_test:
     :path: ".symlinks/plugins/integration_test/ios"
   package_info_plus:
@@ -45,8 +45,8 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   Braintree: adb5125c072eb2b79f84260715dac33ce703ce68
-  braintree_payment: ada720f69d06f6bbc8821ff98acb82853c444356
   Flutter: e0871f40cf51350855a761d2e70bf5af5b9b5de7
+  flutter_braintree_payment: cbaf0b2fd66eb04ea151ee071f109f719a63da2e
   integration_test: 4a889634ef21a45d28d50d622cf412dc6d9f586e
   package_info_plus: af8e2ca6888548050f16fa2f1938db7b5a5df499
 

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -25,5 +25,5 @@ dev_dependencies:
 
 flutter:
   uses-material-design: true
-  assets:
-    - .env
+  # assets:
+  #   - .env

--- a/ios/Classes/BraintreePaymentPlugin.swift
+++ b/ios/Classes/BraintreePaymentPlugin.swift
@@ -105,6 +105,24 @@ public class BraintreePaymentPlugin: NSObject, FlutterPlugin {
         }
         let currencyCode = args[Constants.CURRENCY_CODE_KEY] as? String
 
+        let paymentIntent = args[Constants.PAYMENT_INTENT] as? String?
+        let intent: BTPayPalRequestIntent
+        if paymentIntent == "sale" {
+            intent = .sale
+        } else if paymentIntent == "order" {
+            intent = .order
+        } else {
+            intent = .authorize // Fallback to authorize
+        }
+
+        let uAction = args[Constants.USER_ACTION] as? String?
+        let userAction: BTPayPalRequestUserAction
+        if uAction == "commit" {
+            userAction = .payNow
+        } else {
+            userAction = .none
+        }
+
         // Initialize Braintree API Client
         guard let apiClient = BTAPIClient(authorization: token) else {
             flutterResult?(
@@ -114,7 +132,7 @@ public class BraintreePaymentPlugin: NSObject, FlutterPlugin {
         }
 
         let payPalClient = BTPayPalClient(apiClient: apiClient)
-        let request = BTPayPalCheckoutRequest(amount: amountString, currencyCode: currencyCode)
+        let request = BTPayPalCheckoutRequest(amount: amountString, intent: intent, userAction: userAction, currencyCode: currencyCode)
 
         // Tokenize PayPal payment
         payPalClient.tokenize(request) { tokenizedPayPalAccount, error in
@@ -236,6 +254,8 @@ public struct Constants {
     static let CURRENCY_CODE_KEY = "currencyCode"
     static let IOS_UNIVERSAL_LINK_RETURN_URL = "iosUniversalLinkReturnUrl"
     static let DISPLAY_NAME_KEY = "displayName"
+    static let PAYMENT_INTENT = "paymentIntent"
+    static let USER_ACTION = "userAction"
 
     // Response keys
     static let NONCE_KEY = "nonce"

--- a/lib/paypal/paypal_request.dart
+++ b/lib/paypal/paypal_request.dart
@@ -7,6 +7,7 @@ class PayPalRequest {
     required this.androidAppLinkReturnUrl,
     this.androidDeepLinkFallbackUrlScheme,
     this.billingAgreementDescription,
+    this.paymentIntent,
   });
 
   final String token;
@@ -16,6 +17,7 @@ class PayPalRequest {
   final String androidAppLinkReturnUrl;
   final String? androidDeepLinkFallbackUrlScheme;
   final String? billingAgreementDescription;
+  final String? paymentIntent;
 
   Map<String, dynamic> toJson() {
     return {
@@ -26,6 +28,7 @@ class PayPalRequest {
       'androidAppLinkReturnUrl': androidAppLinkReturnUrl,
       'androidDeepLinkFallbackUrlScheme': androidDeepLinkFallbackUrlScheme,
       'billingAgreementDescription': billingAgreementDescription,
+      'intent': paymentIntent,
     };
   }
 }

--- a/lib/paypal/paypal_request.dart
+++ b/lib/paypal/paypal_request.dart
@@ -1,3 +1,7 @@
+enum PaymentIntent { sale, order, authorize }
+
+enum PaymentUserAction { commit }
+
 class PayPalRequest {
   PayPalRequest({
     required this.token,
@@ -8,6 +12,7 @@ class PayPalRequest {
     this.androidDeepLinkFallbackUrlScheme,
     this.billingAgreementDescription,
     this.paymentIntent,
+    this.userAction,
   });
 
   final String token;
@@ -17,7 +22,8 @@ class PayPalRequest {
   final String androidAppLinkReturnUrl;
   final String? androidDeepLinkFallbackUrlScheme;
   final String? billingAgreementDescription;
-  final String? paymentIntent;
+  final PaymentIntent? paymentIntent;
+  final PaymentUserAction? userAction;
 
   Map<String, dynamic> toJson() {
     return {
@@ -28,7 +34,8 @@ class PayPalRequest {
       'androidAppLinkReturnUrl': androidAppLinkReturnUrl,
       'androidDeepLinkFallbackUrlScheme': androidDeepLinkFallbackUrlScheme,
       'billingAgreementDescription': billingAgreementDescription,
-      'intent': paymentIntent,
+      'paymentIntent': paymentIntent?.name,
+      'userAction': userAction?.name,
     };
   }
 }


### PR DESCRIPTION
This pull request introduces enhancements to the PayPal integration in the Flutter package by adding support for specifying the payment intent and user action, which are required to improve the checkout experience.

Changes Made:
Added Payment Intent: Included the ability to specify the payment intent as either sale or order. This ensures the amount is correctly displayed during the PayPal checkout process, addressing the missing intent configuration from the Flutter client.

Added User Action: Implemented the commit user action to display the "Purchase" button in the PayPal checkout UI, enhancing user clarity and interaction. This was not previously requested by the client but is necessary for a seamless checkout flow.

These changes improve the PayPal checkout experience by ensuring proper amount display and a clear call-to-action for users.

Related Issues
Fixes missing payment intent configuration.
Addresses the absence of the "Purchase" button in the PayPal checkout UI.

Testing
Verified that the payment intent (sale or order) is correctly passed to PayPal and displays the amount in the checkout.
Confirmed that the commit user action renders the "Purchase" button as expected.
Tested the integration in a Flutter environment to ensure compatibility and functionality.

Checklist
Code follows the project's style guidelines.
Changes have been tested thoroughly.
Documentation has been updated (if applicable).


No breaking changes introduced.

Please review the changes and provide feedback. Let me know if additional adjustments are needed!