### PR TITLE
Fix/android app link scheme

### DIFF
--- a/android/src/main/kotlin/com/braintree/payment/PayPalActivity.kt
+++ b/android/src/main/kotlin/com/braintree/payment/PayPalActivity.kt
@@ -50,7 +50,7 @@ class PayPalActivity : ComponentActivity() {
         paypalClient = PayPalClient(
             context = this,
             authorization = token,
-            appLinkReturnUrl = Uri.parse("$appLinkReturnUrl.paypal"),
+            appLinkReturnUrl = Uri.parse("$appLinkReturnUrl.paypal://"),
             deepLinkFallbackUrlScheme = "$deepLinkFallbackUrlScheme.paypal",
         )
 

--- a/android/src/main/kotlin/com/braintree/payment/PayPalActivity.kt
+++ b/android/src/main/kotlin/com/braintree/payment/PayPalActivity.kt
@@ -50,8 +50,8 @@ class PayPalActivity : ComponentActivity() {
         paypalClient = PayPalClient(
             context = this,
             authorization = token,
-            appLinkReturnUrl = Uri.parse("$appLinkReturnUrl.paypal://"),
-            deepLinkFallbackUrlScheme = "$deepLinkFallbackUrlScheme.paypal",
+            appLinkReturnUrl = resolveAppLinkReturnUrl(appLinkReturnUrl, "paypal"),
+            deepLinkFallbackUrlScheme = resolveFallbackScheme(deepLinkFallbackUrlScheme, "paypal"),
         )
 
         val payPalRequest = PayPalCheckoutRequest(
@@ -170,6 +170,27 @@ class PayPalActivity : ComponentActivity() {
             }
             storedPendingRequest = null
         }
+    }
+
+    private fun resolveAppLinkReturnUrl(raw: String, suffix: String): Uri {
+        val value = raw.trim()
+        if (value.contains("://")) {
+            return Uri.parse(value)
+        }
+        return Uri.parse("$value.$suffix://")
+    }
+
+    private fun resolveFallbackScheme(raw: String?, suffix: String): String {
+        val value = raw?.trim().orEmpty()
+        if (value.isEmpty()) {
+            return value
+        }
+        val scheme = if (value.contains("://")) {
+            Uri.parse(value).scheme ?: value
+        } else {
+            value
+        }
+        return if (scheme.endsWith(".$suffix")) scheme else "$scheme.$suffix"
     }
 
     private fun completePayPalFlow(paymentAuthResult: PayPalPaymentAuthResult.Success) {

--- a/android/src/main/kotlin/com/braintree/payment/PayPalActivity.kt
+++ b/android/src/main/kotlin/com/braintree/payment/PayPalActivity.kt
@@ -177,7 +177,8 @@ class PayPalActivity : ComponentActivity() {
         if (value.contains("://")) {
             return Uri.parse(value)
         }
-        return Uri.parse("$value.$suffix://")
+        val scheme = if (value.endsWith(".$suffix")) value else "$value.$suffix"
+        return Uri.parse(scheme)
     }
 
     private fun resolveFallbackScheme(raw: String?, suffix: String): String {

--- a/android/src/main/kotlin/com/braintree/payment/VenmoActivity.kt
+++ b/android/src/main/kotlin/com/braintree/payment/VenmoActivity.kt
@@ -44,7 +44,7 @@ class VenmoActivity : ComponentActivity() {
         venmoClient = VenmoClient(
             context = this,
             authorization = token,
-            appLinkReturnUrl = Uri.parse("$appLinkReturnUrl.venmo"),
+            appLinkReturnUrl = Uri.parse("$appLinkReturnUrl.venmo://"),
             deepLinkFallbackUrlScheme = "$deepLinkFallbackUrlScheme.venmo",
         )
 

--- a/android/src/main/kotlin/com/braintree/payment/VenmoActivity.kt
+++ b/android/src/main/kotlin/com/braintree/payment/VenmoActivity.kt
@@ -129,7 +129,8 @@ class VenmoActivity : ComponentActivity() {
         if (value.contains("://")) {
             return Uri.parse(value)
         }
-        return Uri.parse("$value.$suffix://")
+        val scheme = if (value.endsWith(".$suffix")) value else "$value.$suffix"
+        return Uri.parse(scheme)
     }
 
     private fun resolveFallbackScheme(raw: String?, suffix: String): String {

--- a/android/src/main/kotlin/com/braintree/payment/VenmoActivity.kt
+++ b/android/src/main/kotlin/com/braintree/payment/VenmoActivity.kt
@@ -44,8 +44,8 @@ class VenmoActivity : ComponentActivity() {
         venmoClient = VenmoClient(
             context = this,
             authorization = token,
-            appLinkReturnUrl = Uri.parse("$appLinkReturnUrl.venmo://"),
-            deepLinkFallbackUrlScheme = "$deepLinkFallbackUrlScheme.venmo",
+            appLinkReturnUrl = resolveAppLinkReturnUrl(appLinkReturnUrl, "venmo"),
+            deepLinkFallbackUrlScheme = resolveFallbackScheme(deepLinkFallbackUrlScheme, "venmo"),
         )
 
         val venmoRequest = VenmoRequest(
@@ -122,6 +122,27 @@ class VenmoActivity : ComponentActivity() {
         super.onResume()
         Log.d("BraintreePaymentPlugin", "onResume, intent: $intent")
         handleReturnToApp(intent)
+    }
+
+    private fun resolveAppLinkReturnUrl(raw: String, suffix: String): Uri {
+        val value = raw.trim()
+        if (value.contains("://")) {
+            return Uri.parse(value)
+        }
+        return Uri.parse("$value.$suffix://")
+    }
+
+    private fun resolveFallbackScheme(raw: String?, suffix: String): String {
+        val value = raw?.trim().orEmpty()
+        if (value.isEmpty()) {
+            return value
+        }
+        val scheme = if (value.contains("://")) {
+            Uri.parse(value).scheme ?: value
+        } else {
+            value
+        }
+        return if (scheme.endsWith(".$suffix")) scheme else "$scheme.$suffix"
     }
 
     private fun handleReturnToApp(intent: Intent) {


### PR DESCRIPTION
  Title
  Fix Android return URL scheme formatting for Braintree app switch

  Body

  ## Summary
  - Fix Android app switch return URL formatting so Braintree gets a valid `return_url`.
  - Ensure scheme-only URLs are created without `://`.
  - Preserve existing behavior for full app-link URLs (https).

  ## Context
  Braintree builds `return_url` values like `${scheme}://onetouch/v1/success`.
  When we passed `https://…/braintree_payments` the resulting URL became invalid
  (`https://…/braintree_payments.paypal://…`) and PayPal returned `422 Invalid URL`.

  ## Changes
  - `PayPalActivity.resolveAppLinkReturnUrl` now returns `<scheme>.<suffix>` (no `://`).
  - `VenmoActivity.resolveAppLinkReturnUrl` now returns `<scheme>.<suffix>` (no `://`).
  - Full URLs containing `://` still pass through unchanged.

  ## How to test
  1) Build the Flutter app with `flutter_braintree_payment`.
  2) Trigger PayPal (or Venmo) payment on Android.
  3) Verify app switch proceeds and no `422 Invalid URL` is returned.

  ## Notes
  - This keeps compatibility with app-link URLs if they are explicitly provided.
  - The change is limited to Android app switch return URL construction.
